### PR TITLE
Added cloning and copying of utf repo files

### DIFF
--- a/scripts/config_build.txt
+++ b/scripts/config_build.txt
@@ -14,7 +14,7 @@ DEPENDENCIES/seattlelib_v2/*
 DEPENDENCIES/repy_v2/*
 DEPENDENCIES/portability/*
 DEPENDENCIES/common/*
-DEPENDENCIES/common/utf/*
+DEPENDENCIES/utf/*
 DEPENDENCIES/common/seattleclearinghouse_xmlrpc.py
 DEPENDENCIES/affix/*
 DEPENDENCIES/affix/components/*
@@ -25,7 +25,7 @@ DEPENDENCIES/nodemanager/runonce.py
 DEPENDENCIES/softwareupdater/generatekeys.py
 
 # Tests
-test DEPENDENCIES/common/utf/*
+test DEPENDENCIES/utf/*
 test DEPENDENCIES/seattlelib_v2/tests/*
 test DEPENDENCIES/clearinghouse/tests/*
 test DEPENDENCIES/repy_v2/testsV2/*

--- a/scripts/config_initialize.txt
+++ b/scripts/config_initialize.txt
@@ -17,4 +17,4 @@ https://github.com/SeattleTestbed/portability ../DEPENDENCIES/portability
 https://github.com/SeattleTestbed/affix.git ../DEPENDENCIES/affix
 https://github.com/SeattleTestbed/seash.git ../DEPENDENCIES/seash
 https://github.com/SeattleTestbed/resource.git ../DEPENDENCIES/resource
-
+https://github.com/SeattleTestbed/utf ../DEPENDENCIES/utf


### PR DESCRIPTION
'utf' directory is to be deleted from 'common' repo and to be cloned separately from its own repo.
Hence, build-scripts needs to be updated to reflect that change.
This PR takes care of that.