### PR TITLE
Made changes to start_clearinghouse_components.sh

### DIFF
--- a/deploymentscripts/start_clearinghouse_components.sh
+++ b/deploymentscripts/start_clearinghouse_components.sh
@@ -68,7 +68,8 @@ function shutdown() {
   echo "Shutting down Clearinghouse components."
   # Tell kill to kill the process group (so, kill children) by giving a negative process id.
   # Note: "--" means the end of options
-  kill -- -$$
+  #kill -- -$$
+  pkill -P $$
   wait
   exit
 }

--- a/website/settings.py
+++ b/website/settings.py
@@ -56,7 +56,7 @@ SEATTLECLEARINGHOUSE_INSTALLER_BUILDER_XMLRPC = "https://custombuilder.poly.edu/
 
 # Not currently used. This is left in for legacy installs
 #The url that corresponds to SEATTLECLEARINGHOUSE_USER_INSTALLERS_DIR
-#SEATTLECLEARINGHOUSE_USER_INSTALLERS_URL = "https://blackbox.cs.washington.edu/dist/geni"
+
 
 # Need to specify the LOGIN_URL, as our login page isn't at the default login
 # location (the default is /accounts/login).


### PR DESCRIPTION
when i used CTRL+C to terminate shell script but ubuntu reported segfault. Changed the kill command and i think the script works now without segfault.