### PR TITLE
Fixes typo in rarely used variable

### DIFF
--- a/deploymentscripts/deploy_clearinghouse.py
+++ b/deploymentscripts/deploy_clearinghouse.py
@@ -96,7 +96,7 @@ def main():
       print("")
       renameddir = deployroot.rstrip('/').rstrip('\\') + '.bak.' + str(time.time())
       print("Renaming existing directory {0} to {1}".format(deployroot,
-          renamedir))
+          renameddir))
       shutil.move(deployroot, renameddir)
 
   # Create the directory we will deploy to.


### PR DESCRIPTION
Fixes typo in variable that is only accessed if the deployment script wants to deploy the clearinghouse in a directory that already exists.

Note: If the the directory does exist the deployment script expects it to have certain files in it, or else it crashes.