### PR TITLE
Fix custominstallerbuilder/issue#16

### DIFF
--- a/website/context_processor.py
+++ b/website/context_processor.py
@@ -11,10 +11,14 @@ def customizable_strings(request):
 }
 
 def options(request):
-    """Make variables defined in settings.py available to the template engine."""
+    """ If 'clearinghouse.website.context_processor.options'
+    is added to TEMPLATE_CONTEXT_PROCESSORS in settings.py the items of the
+    returned dict can be directly accessed in the template engine.
+    Currently we only make the boolean DEBUG setting available."""
+
     from django.conf import settings
     return {
-        # A debug variable is available to the templates via django's
+        # A debug variable is available to the templates via django's built-in
         # 'django.core.context_processors.debug', but only if the request's
         # IP address is listed in the INTERNAL_IPS setting, c.f.:
         # https://docs.djangoproject.com/en/1.9/ref/templates/api/#django-template-context-processors-debug

--- a/website/context_processor.py
+++ b/website/context_processor.py
@@ -18,5 +18,5 @@ def options(request):
         # 'django.core.context_processors.debug', but only if the request's
         # IP address is listed in the INTERNAL_IPS setting, c.f.:
         # https://docs.djangoproject.com/en/1.9/ref/templates/api/#django-template-context-processors-debug
-        "DEBUG" : "settings.DEBUG",
+        "DEBUG" : settings.DEBUG,
         }

--- a/website/context_processor.py
+++ b/website/context_processor.py
@@ -9,3 +9,14 @@ def customizable_strings(request):
       "CLEARINGHOUSE_URL": settings.CLEARINGHOUSE_URL,
       "DEMOKIT": settings.DEMOKIT,
 }
+
+def options(request):
+    """Make variables defined in settings.py available to the template engine."""
+    from django.conf import settings
+    return {
+        # A debug variable is available to the templates via django's
+        # 'django.core.context_processors.debug', but only if the request's
+        # IP address is listed in the INTERNAL_IPS setting, c.f.:
+        # https://docs.djangoproject.com/en/1.9/ref/templates/api/#django-template-context-processors-debug
+        "DEBUG" : "settings.DEBUG",
+        }

--- a/website/html/templates/common/debug_warning.html
+++ b/website/html/templates/common/debug_warning.html
@@ -1,0 +1,3 @@
+<div class="warning">
+    WARNING: you are in DEBUG mode. Change settings.DEBUG to False in production!
+</div>

--- a/website/html/templates/common/geni_base.html
+++ b/website/html/templates/common/geni_base.html
@@ -44,6 +44,9 @@
 </head>
 
 <body>
+  {% if DEBUG %}
+    {% include "common/debug_warning.html" %}
+  {% endif %}
   {% block header %}	
 	  <div id="header">
   		<span id="logo"><a href="{% url 'profile' %}">{{ TESTBED }} {{ CLEARINGHOUSE }}</a></span>

--- a/website/html/views.py
+++ b/website/html/views.py
@@ -22,6 +22,8 @@ import sys
 import shutil
 import subprocess
 import xmlrpclib
+import re
+import ssl
 
 # Needed to escape characters for the Android referrer...
 import urllib
@@ -1112,7 +1114,17 @@ def _build_installer(username, platform):
     return False, error_response
 
   try:
-    xmlrpc_proxy = xmlrpclib.ServerProxy(settings.SEATTLECLEARINGHOUSE_INSTALLER_BUILDER_XMLRPC)
+    # Per default this setting is True in DEBUG mode.
+    # Passing an unverified ssl context allows the Custom Installer Builder
+    # to use self-signed server certificates.
+    # c.f. https://github.com/SeattleTestbed/custominstallerbuilder/issues/16
+    if settings.UNVERIFIED_SSL_CONTEXT:
+      xmlrpc_proxy = xmlrpclib.ServerProxy(
+        settings.SEATTLECLEARINGHOUSE_INSTALLER_BUILDER_XMLRPC, 
+        context=ssl._create_unverified_context())
+    else:
+      xmlrpc_proxy = xmlrpclib.ServerProxy(
+        settings.SEATTLECLEARINGHOUSE_INSTALLER_BUILDER_XMLRPC)
     
     vessel_list = [{'percentage': 80, 'owner': 'owner', 'users': ['user']}]
     

--- a/website/html/views.py
+++ b/website/html/views.py
@@ -22,7 +22,6 @@ import sys
 import shutil
 import subprocess
 import xmlrpclib
-import re
 import ssl
 
 # Needed to escape characters for the Android referrer...

--- a/website/settings.py
+++ b/website/settings.py
@@ -50,6 +50,13 @@ SEATTLECLEARINGHOUSE_STATE_KEYS_DIR = os.path.join(SEATTLECLEARINGHOUSE_WEBSITE_
 SEATTLECLEARINGHOUSE_INSTALLER_BUILDER_XMLRPC = "https://custombuilder.poly.edu/custom_install/xmlrpc/" # Default, currently no repy_v2 support
 #SEATTLECLEARINGHOUSE_INSTALLER_BUILDER_XMLRPC = "https://sensibilityclearinghouse.poly.edu/custominstallerbuilder/xmlrpc/" # SensibilityTestbed's CIB, which supports repy_v2 and thereby NAT traversal.
 
+# In Python 2.7.9+ a HTTPS request to a server using a self-signed certificate
+# will raise an exception.
+# This setting provides to chose whether to accept self-signed certificates
+# (e.g. in DEBUG mode) by using an unverified ssl context.
+# c.f. https://github.com/SeattleTestbed/custominstallerbuilder/issues/16
+UNVERIFIED_SSL_CONTEXT = DEBUG
+
 # Not currently used. This is left in for legacy installs
 # The directory where the base installers named seattle_linux.tgz, seattle_mac.tgz,
 # and seattle_win.zip are located.

--- a/website/settings.py
+++ b/website/settings.py
@@ -52,9 +52,10 @@ SEATTLECLEARINGHOUSE_INSTALLER_BUILDER_XMLRPC = "https://custombuilder.poly.edu/
 
 # In Python 2.7.9+ a HTTPS request to a server using a self-signed certificate
 # will raise an exception.
-# This setting provides to chose whether to accept self-signed certificates
-# (e.g. in DEBUG mode) by using an unverified ssl context.
+# If set to `True` the SSL context is not verified for HTTPS XMLRPC requests
+# and therefore allows the use of self-signed certificates.
 # c.f. https://github.com/SeattleTestbed/custominstallerbuilder/issues/16
+# NOTE: Don't set to `True` in production!
 UNVERIFIED_SSL_CONTEXT = DEBUG
 
 # Not currently used. This is left in for legacy installs

--- a/website/settings.py
+++ b/website/settings.py
@@ -257,6 +257,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
   'social_auth.context_processors.social_auth_by_type_backends',
   # Add context processor for TESTBED etc. tags; configure these below.
   'clearinghouse.website.context_processor.customizable_strings',
+  'clearinghouse.website.context_processor.options',
 )
 #  Social_auth follows each of these in order and passes along a object with
 #  information gathered to each function.


### PR DESCRIPTION
Fixes [custominstallerbuilder/issue16](https://github.com/SeattleTestbed/custominstallerbuilder/issues/16)
1. Adds big red warning to all web pages when `DEBUG` option is set to true.
2. Adds option to chose whether the Clearinghouse should be able to communicate with a Custom Installer Builder via XMLRPC if the Custom Installer Builder uses _self-signed certificates_.
   Option defaults to the same value as `DEBUG` option.

There are more parts in the Clearinghouse code that use XMLRPC but were not changed because they either don't use SSL or aren't probably used at all:
- [lockserver](https://github.com/SeattleTestbed/clearinghouse/blob/master/common/api/lockserver.py#L351)
- [backend](https://github.com/SeattleTestbed/clearinghouse/blob/master/common/api/backend.py#L63)
- [lock_contention](https://github.com/SeattleTestbed/clearinghouse/blob/master/lockserver/tests/integration/lock_contention.py)
- [ut_integration_lock_contention.py](https://github.com/SeattleTestbed/clearinghouse/blob/master/lockserver/tests/integration/ut_integration_lock_contention.py)
- [example1](https://github.com/SeattleTestbed/clearinghouse/blob/master/xmlrpc_clients/examples/example1.py#L27)
