### PR TITLE
Replace deprecated MySQL system variable, fix #176

### DIFF
--- a/website/settings.py
+++ b/website/settings.py
@@ -106,25 +106,24 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
-# Database
-# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+# Take a look at https://docs.djangoproject.com/en/1.8/ref/databases/
+# to learn more about Django and databases.
+# You can use other databases like Postgres or SQLite as well.
 DATABASES = {
     'default': {
-        # you can use django.db.backends.sqlite3 instead of mysql. If you
-        # decide to do so, you can leave the other fields empty
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'FILL_THIS_IN',
         'USER': 'FILL_THIS_IN',
         'PASSWORD': 'FILL_THIS_IN',
         'HOST': '',
         'PORT': '',
+        'OPTIONS': {
+            # INNODB is ully transactional and supports foreign key references
+            # (default since MySQL 5.5.5)
+            'init_command': 'SET default_storage_engine=INNODB'
+        }
     }
 }
-
-if DATABASES['default']['ENGINE'] == 'django.db.backends.mysql':
-    DATABASES['default']['OPTIONS'] = {}
-    DATABASES['default']['OPTIONS']['init_command'] = \
-            'SET storage_engine=INNODB'
 
 # Make this unique, and don't share it with anybody.
 # Fill this in!

--- a/website/settings.py
+++ b/website/settings.py
@@ -118,7 +118,7 @@ DATABASES = {
         'HOST': '',
         'PORT': '',
         'OPTIONS': {
-            # INNODB is ully transactional and supports foreign key references
+            # INNODB is fully transactional and supports foreign key references
             # (default since MySQL 5.5.5)
             'init_command': 'SET default_storage_engine=INNODB'
         }


### PR DESCRIPTION
Fixes https://github.com/SeattleTestbed/clearinghouse/issues/176 by replacing MySQL system variable `storage_engine` with `default_storage_engine` because former is deprecated and was removed in [MySQL 5.7.5](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_default_storage_engine). Latter was added in [5.5.3](https://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html#sysvar_default_storage_engine).

This commit also moves said setting into Django's DB setting dictionary to de-clutter the code.